### PR TITLE
#2 Refactor: Updated test_construction_from_string::test_period_range…

### DIFF
--- a/pandas/tests/indexes/period/test_period_range.py
+++ b/pandas/tests/indexes/period/test_period_range.py
@@ -79,10 +79,16 @@ class TestPeriodRange:
     @pytest.mark.parametrize(
         "freq_offset, freq_period",
         [
+            ("h", "h"),
+            ("7h", "7h"),
             ("D", "D"),
-            ("W", "W"),
-            ("QE", "Q"),
+            ("15D", "15D"),
+            ("ME", "M"),
+            ("3ME", "3M"),
             ("YE", "Y"),
+            ("8YE", "8Y"),
+            ("20s", "20s"),
+            ("2QE", "2Q"),
         ],
     )
     def test_construction_from_string(self, freq_offset, freq_period):
@@ -111,34 +117,6 @@ class TestPeriodRange:
         tm.assert_index_equal(result, expected)
 
         result = period_range(start=end, end=start, freq=freq_period, name="foo")
-        tm.assert_index_equal(result, expected)
-
-    def test_construction_from_string_monthly(self):
-        # non-empty
-        expected = date_range(
-            start="2017-01-01", periods=5, freq="ME", name="foo"
-        ).to_period()
-        start, end = str(expected[0]), str(expected[-1])
-
-        result = period_range(start=start, end=end, freq="M", name="foo")
-        tm.assert_index_equal(result, expected)
-
-        result = period_range(start=start, periods=5, freq="M", name="foo")
-        tm.assert_index_equal(result, expected)
-
-        result = period_range(end=end, periods=5, freq="M", name="foo")
-        tm.assert_index_equal(result, expected)
-
-        # empty
-        expected = PeriodIndex([], freq="M", name="foo")
-
-        result = period_range(start=start, periods=0, freq="M", name="foo")
-        tm.assert_index_equal(result, expected)
-
-        result = period_range(end=end, periods=0, freq="M", name="foo")
-        tm.assert_index_equal(result, expected)
-
-        result = period_range(start=end, end=start, freq="M", name="foo")
         tm.assert_index_equal(result, expected)
 
     def test_construction_from_period(self):


### PR DESCRIPTION
….py to test frequencies with koefficient > 1. Also removed redundant test called test_construction_from_string_monthly since the updated test_construction_from_string covers the same thing.

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
